### PR TITLE
TVL now based on farm TVL and not pool TVL

### DIFF
--- a/src/features/onsen/FarmListItem.tsx
+++ b/src/features/onsen/FarmListItem.tsx
@@ -69,7 +69,7 @@ const FarmListItem: FC<FarmListItem> = ({ farm, onClick }) => {
             ? farm?.roiPerYear > 10000
               ? '>10,000%'
               : formatPercent(farm?.roiPerYear * 100)
-            : 'Infinite'}
+            : '-'}
           {!!farm?.feeApyPerYear && (
             <QuestionHelper
               text={
@@ -80,7 +80,7 @@ const FarmListItem: FC<FarmListItem> = ({ farm, onClick }) => {
                       ? farm?.rewardAprPerYear > 10000
                         ? '>10,000%'
                         : formatPercent(farm?.rewardAprPerYear * 100)
-                      : 'Infinite'}
+                      : '-'}
                   </div>
                   <div>
                     Fee APR: {farm?.feeApyPerYear < 10000 ? formatPercent(farm?.feeApyPerYear * 100) : '>10,000%'}

--- a/src/hooks/useFarmRewards.ts
+++ b/src/hooks/useFarmRewards.ts
@@ -148,7 +148,8 @@ export default function useFarmRewards({ chainId = ChainId.CELO }) {
     // const balance = swapPair ? Number(pool.balance / 1e18) : pool.balance / 10 ** kashiPair.token0.decimals
     const balance = swapSymmPair ? Number(pool.balance / 1e18) : pool.balance / 10
 
-    const tvl = swapSymmPair.totalLiquidity
+    // const tvl = swapSymmPair.totalLiquidity
+    const tvl = (swapSymmPair.totalLiquidity / swapSymmPair.totalShares) * pool.slpBalance * 0.000000000000000001
 
     // const feeApyPerYear =
     //   swapPair && swapPair1d


### PR DESCRIPTION
totalLiquidity is representing totalLiquidity in a pool rather than in the farm which could be less.
slpBalance represents the number of tokens in the farm so this change calculates the value per share and multiples that by the number of shares in the farm to give the liquidity loaded in the farm.

The result for farms right now is very close to what's in the pools since shares are mostly loaded into farms but several new pools have no liquidity being reported and so the APR was showing as infinity (n rewards shared by 0 shares). That looks a bit strange so I've changed this to show as "-' rather than 'infinity'.