### PR TITLE
Corrected TVL to calculate TVL for farm, not pool

### DIFF
--- a/src/features/onsen/FarmListItem.tsx
+++ b/src/features/onsen/FarmListItem.tsx
@@ -69,7 +69,7 @@ const FarmListItem: FC<FarmListItem> = ({ farm, onClick }) => {
             ? farm?.roiPerYear > 10000
               ? '>10,000%'
               : formatPercent(farm?.roiPerYear * 100)
-            : 'Infinite'}
+            : '-'}
           {!!farm?.feeApyPerYear && (
             <QuestionHelper
               text={
@@ -80,7 +80,7 @@ const FarmListItem: FC<FarmListItem> = ({ farm, onClick }) => {
                       ? farm?.rewardAprPerYear > 10000
                         ? '>10,000%'
                         : formatPercent(farm?.rewardAprPerYear * 100)
-                      : 'Infinite'}
+                      : '-'}
                   </div>
                   <div>
                     Fee APR: {farm?.feeApyPerYear < 10000 ? formatPercent(farm?.feeApyPerYear * 100) : '>10,000%'}

--- a/src/hooks/useFarmRewards.ts
+++ b/src/hooks/useFarmRewards.ts
@@ -171,7 +171,8 @@ export default function useFarmRewards({ chainId = ChainId.CELO }) {
     // const balance = swapPair ? Number(pool.balance / 1e18) : pool.balance / 10 ** kashiPair.token0.decimals
     const balance = swapSymmPair ? Number(pool.balance / 1e18) : pool.balance / 10
 
-    const tvl = swapSymmPair.totalLiquidity
+    // const tvl = swapSymmPair.totalLiquidity
+    const tvl = (swapSymmPair.totalLiquidity / swapSymmPair.totalShares) * pool.slpBalance * 0.000000000000000001
 
     // const feeApyPerYear =
     //   swapPair && swapPair1d


### PR DESCRIPTION
TVL should represent TVL in the farm and not the pool.
This change takes the total amount of liquidity in the pool and divides it by the number of shares in the pool to get a price per share. This is then multiplied by the number of shares in the farm, adjusted for 18 decimal places.

A second change is for situations that a pool has no liquidity which is a rare edge case. But in that situation we don't show APR as 'infinity' but as '-' 